### PR TITLE
WIP Indicate when the contact details were last updated

### DIFF
--- a/models/aged_creditor.json
+++ b/models/aged_creditor.json
@@ -2,6 +2,8 @@
     "fact_table": "aged_creditor_facts",
     "label": "Aged Creditor Analysis",
     "description": "This is based on the AC and ACA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/aged_debtor.json
+++ b/models/aged_debtor.json
@@ -2,6 +2,8 @@
     "fact_table": "aged_debtor_facts",
     "label": "Aged Debtor Analysis",
     "description": "This is based on the AD and ADA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/audit_opinions.json
+++ b/models/audit_opinions.json
@@ -2,6 +2,8 @@
     "fact_table": "audit_opinion_facts",
     "label": "Audit Opinions",
     "description": "",
+    "update_cycle": "year",
+    "last_updated": "2015",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/badexp.json
+++ b/models/badexp.json
@@ -2,6 +2,8 @@
     "fact_table": "badexp_facts",
     "label": " Unauthorised, Irregular, Fruitless and Wasteful Expenditure",
     "description": "An audit outcome. Must be recorded in the notes to the annual financial statements",
+    "update_cycle": "year",
+    "last_updated": "2015",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/bsheet.json
+++ b/models/bsheet.json
@@ -2,6 +2,8 @@
     "fact_table": "bsheet_facts",
     "label": "Balance Sheet",
     "description": "Statement of Financial Position. This is based on the BS, BSR, BSAC and BSA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/capital.json
+++ b/models/capital.json
@@ -2,6 +2,8 @@
     "fact_table": "capital_facts",
     "label": "Capital Aquisition",
     "description": "This is based on the CA, CAR, CAA and CAAA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/cflow.json
+++ b/models/cflow.json
@@ -2,6 +2,8 @@
     "fact_table": "cflow_facts",
     "label": "Cash Flow",
     "description": "This is based on the CFB, CFR, CFA and CFAA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/conditional_grants.json
+++ b/models/conditional_grants.json
@@ -2,6 +2,8 @@
     "fact_table": "conditional_grants_facts",
     "label": "Conditional Grants",
     "description": "This is based on the return forms for individual grants.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/incexp.json
+++ b/models/incexp.json
@@ -2,6 +2,8 @@
     "fact_table": "incexp_facts",
     "label": "Income and Expenditure",
     "description": "Statement of financial performance. This is based on the OSB, OSR, OSA and OSAA return forms.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/models/municipalities.json
+++ b/models/municipalities.json
@@ -1,7 +1,9 @@
 {
     "fact_table": "scorecard_geography",
     "label": "Municipalities",
-    "description": "",
+    "description": "General information about the municipality including its geographic location and contact details provided to the National Treasury",
+    "update_cycle": "quarter",
+    "last_updated": "2016-06",
     "dimensions": {
         "municipality": {
             "label": "Municipality",

--- a/models/officials.json
+++ b/models/officials.json
@@ -1,7 +1,9 @@
 {
     "fact_table": "municipality_staff_contacts",
     "label": "Municipal Officials",
-    "description": "",
+    "description": "Names and contact information for high level municipality staff",
+    "update_cycle": "quarter",
+    "last_updated": "2016-06",
     "dimensions": {
         "municipality": {
             "label": "Municipality",

--- a/models/repmaint.json
+++ b/models/repmaint.json
@@ -2,6 +2,8 @@
     "fact_table": "repmaint_facts",
     "label": "Repairs and Maintenance",
     "description": "This is based on the RME return form.",
+    "update_cycle": "quarter",
+    "last_updated": "2015-06",
     "dimensions": {
         "demarcation": {
             "attributes": {

--- a/scorecard/profile_data.py
+++ b/scorecard/profile_data.py
@@ -1,6 +1,9 @@
 from concurrent.futures import ThreadPoolExecutor
 from requests_futures.sessions import FuturesSession
 from collections import defaultdict, OrderedDict, Counter
+import dateutil.parser
+import copy
+
 
 from django.conf import settings
 
@@ -62,8 +65,10 @@ class MuniApiClient(object):
         response_dict = api_response.result().json()
         if query_params['query_type'] == 'facts':
             results = self.facts_from_response(response_dict, query_params)
-        else:
+        elif query_params['query_type'] == 'aggregate':
             results = self.aggregate_from_response(response_dict, query_params)
+        elif query_params['query_type'] == 'model':
+            results = response_dict['model']
 
         return results
 
@@ -574,5 +579,5 @@ class IndicatorCalculator(object):
         for key in self.results.keys():
             if key.endswith('_model'):
                 name = key.replace('_model', '')
-                models[name] = (self.results[key])
+                models[name] = self.results[key]
         return models

--- a/scorecard/profile_data.py
+++ b/scorecard/profile_data.py
@@ -239,6 +239,10 @@ class MuniApiClient(object):
                 'value_label': '',
                 'query_type': 'facts',
             },
+            'officials_date': {
+                'cube': 'officials',
+                'query_type': 'model',
+            },
             'contact_details' : {
                 'cube': 'municipalities',
                 'cut': {
@@ -268,42 +272,6 @@ class MuniApiClient(object):
                 ],
                 'value_label': 'opinion.label',
                 'query_type': 'facts',
-            },
-            'audit_opinions_model': {
-                'cube': 'audit_opinions',
-                'query_type': 'model',
-            },
-            'badexp_model': {
-                'cube': 'badexp',
-                'query_type': 'model',
-            },
-            'bsheet_model': {
-                'cube': 'bsheet',
-                'query_type': 'model',
-            },
-            'capital_model': {
-                'cube': 'capital',
-                'query_type': 'model',
-            },
-            'cflow_model': {
-                'cube': 'cflow',
-                'query_type': 'model',
-            },
-            'incexp_model': {
-                'cube': 'incexp',
-                'query_type': 'model',
-            },
-            'municipalities_model': {
-                'cube': 'municipalities',
-                'query_type': 'model',
-            },
-            'officials_model': {
-                'cube': 'officials',
-                'query_type': 'model',
-            },
-            'repmaint_model': {
-                'cube': 'repmaint',
-                'query_type': 'model',
             },
         }
 
@@ -537,7 +505,14 @@ class IndicatorCalculator(object):
                 if secretary:
                     official['secretary'] = secretary
 
-        return [officials.get(role) for role in roles]
+        date = self.results['officials_date'].get('last_updated')
+        if date:
+            date = dateutil.parser.parse(date).strftime("%B %Y")
+
+        return {
+            'officials': [officials.get(role) for role in roles],
+            'updated_date': date,
+        }
 
     def muni_contact(self):
         muni_contact = self.results['contact_details'][0]
@@ -573,11 +548,3 @@ class IndicatorCalculator(object):
         values = sorted(values, key=lambda r: r['year'])
         values.reverse()
         return values
-
-    def models(self):
-        models = {}
-        for key in self.results.keys():
-            if key.endswith('_model'):
-                name = key.replace('_model', '')
-                models[name] = self.results[key]
-        return models

--- a/scorecard/profile_data.py
+++ b/scorecard/profile_data.py
@@ -52,6 +52,9 @@ class MuniApiClient(object):
                 'fields': ','.join(field for field in query_params['fields']),
                 'page': 0
             }
+        elif query_params['query_type'] == 'model':
+            url = self.API_URL + query_params['cube'] + '/model'
+            params = {}
         return self.session.get(url, params=params, verify=False)
 
     def response_to_results(self, api_response, query_params):
@@ -260,6 +263,42 @@ class MuniApiClient(object):
                 ],
                 'value_label': 'opinion.label',
                 'query_type': 'facts',
+            },
+            'audit_opinions_model': {
+                'cube': 'audit_opinions',
+                'query_type': 'model',
+            },
+            'badexp_model': {
+                'cube': 'badexp',
+                'query_type': 'model',
+            },
+            'bsheet_model': {
+                'cube': 'bsheet',
+                'query_type': 'model',
+            },
+            'capital_model': {
+                'cube': 'capital',
+                'query_type': 'model',
+            },
+            'cflow_model': {
+                'cube': 'cflow',
+                'query_type': 'model',
+            },
+            'incexp_model': {
+                'cube': 'incexp',
+                'query_type': 'model',
+            },
+            'municipalities_model': {
+                'cube': 'municipalities',
+                'query_type': 'model',
+            },
+            'officials_model': {
+                'cube': 'officials',
+                'query_type': 'model',
+            },
+            'repmaint_model': {
+                'cube': 'repmaint',
+                'query_type': 'model',
             },
         }
 
@@ -529,3 +568,11 @@ class IndicatorCalculator(object):
         values = sorted(values, key=lambda r: r['year'])
         values.reverse()
         return values
+
+    def models(self):
+        models = {}
+        for key in self.results.keys():
+            if key.endswith('_model'):
+                name = key.replace('_model', '')
+                models[name] = (self.results[key])
+        return models

--- a/scorecard/profiles.py
+++ b/scorecard/profiles.py
@@ -13,7 +13,6 @@ def get_profile(geo_code, geo_level, profile_name=None):
     if geo.square_kms:
         population_density = total_pop / geo.square_kms
 
-
     api_client = MuniApiClient(geo_code)
     indicator_calc = IndicatorCalculator(api_client.results, api_client.years)
 
@@ -26,7 +25,6 @@ def get_profile(geo_code, geo_level, profile_name=None):
     indicators['rep_maint_perc_ppe'] = indicator_calc.rep_maint_perc_ppe()
     indicators['wasteful_exp_perc_exp'] = indicator_calc.wasteful_exp_perc_exp()
 
-    import dateutil.parser
     return {
         'total_population': total_pop,
         'population_density': population_density,
@@ -36,6 +34,4 @@ def get_profile(geo_code, geo_level, profile_name=None):
         'indicators': indicators,
         'revenue_breakdown': indicator_calc.revenue_breakdown(),
         'expenditure_breakdown': indicator_calc.expenditure_breakdown(),
-        'models': indicator_calc.models(),
-        'date': dateutil.parser.parse('2016-06'),
     }

--- a/scorecard/profiles.py
+++ b/scorecard/profiles.py
@@ -34,5 +34,6 @@ def get_profile(geo_code, geo_level, profile_name=None):
         'audit_opinions': indicator_calc.audit_opinions(),
         'indicators': indicators,
         'revenue_breakdown': indicator_calc.revenue_breakdown(),
-        'expenditure_breakdown': indicator_calc.expenditure_breakdown()
+        'expenditure_breakdown': indicator_calc.expenditure_breakdown(),
+        'models': indicator_calc.models()
     }

--- a/scorecard/profiles.py
+++ b/scorecard/profiles.py
@@ -26,6 +26,7 @@ def get_profile(geo_code, geo_level, profile_name=None):
     indicators['rep_maint_perc_ppe'] = indicator_calc.rep_maint_perc_ppe()
     indicators['wasteful_exp_perc_exp'] = indicator_calc.wasteful_exp_perc_exp()
 
+    import dateutil.parser
     return {
         'total_population': total_pop,
         'population_density': population_density,
@@ -35,5 +36,6 @@ def get_profile(geo_code, geo_level, profile_name=None):
         'indicators': indicators,
         'revenue_breakdown': indicator_calc.revenue_breakdown(),
         'expenditure_breakdown': indicator_calc.expenditure_breakdown(),
-        'models': indicator_calc.models()
+        'models': indicator_calc.models(),
+        'date': dateutil.parser.parse('2016-06'),
     }

--- a/scorecard/templates/profile/profile_detail.html
+++ b/scorecard/templates/profile/profile_detail.html
@@ -1,5 +1,5 @@
 {% extends '_base.html' %}
-{% load staticfiles pipeline l10n jsonify finance %}
+{% load lookup staticfiles pipeline l10n jsonify finance %}
 
 {% block head_title %}{{ geography.this.short_name }} - {{ block.super }}{% endblock %}
 {% block head_meta_description %}Municipal performance for {{ geography.this.short_name}}, and other information.{% endblock %}
@@ -110,6 +110,13 @@
                 </div>
                 {% endif %}
               {% endfor %}
+            </div>
+          </div>
+          <div class="col-md-8 col-md-pull-4">
+            <div class="row">
+              {% with model=models|get:'officials' %}
+              {{ model|get:'last_updated' }}
+              {% endwith %}
             </div>
           </div>
         </div>

--- a/scorecard/templates/profile/profile_detail.html
+++ b/scorecard/templates/profile/profile_detail.html
@@ -115,7 +115,7 @@
           <div class="col-md-8 col-md-pull-4">
             <div class="row">
               {% with model=models|get:'officials' %}
-              {{ model|get:'last_updated' }}
+              Last updated {{ model|get:'last_updated' }} {{ date|date:"F Y" }}
               {% endwith %}
             </div>
           </div>

--- a/scorecard/templates/profile/profile_detail.html
+++ b/scorecard/templates/profile/profile_detail.html
@@ -1,5 +1,5 @@
 {% extends '_base.html' %}
-{% load lookup staticfiles pipeline l10n jsonify finance %}
+{% load staticfiles pipeline l10n jsonify finance %}
 
 {% block head_title %}{{ geography.this.short_name }} - {{ block.super }}{% endblock %}
 {% block head_meta_description %}Municipal performance for {{ geography.this.short_name}}, and other information.{% endblock %}
@@ -76,7 +76,7 @@
           </div>
           <div class="col-md-8 col-md-pull-4">
             <div class="row">
-              {% for official in mayoral_staff %}
+              {% for official in mayoral_staff.officials %}
                 {% if forloop.counter < 5 %}
                 <div class="col-sm-3">
                   <div class="person-info">
@@ -111,13 +111,10 @@
                 {% endif %}
               {% endfor %}
             </div>
-          </div>
-          <div class="col-md-8 col-md-pull-4">
-            <div class="row">
-              {% with model=models|get:'officials' %}
-              Last updated {{ model|get:'last_updated' }} {{ date|date:"F Y" }}
-              {% endwith %}
-            </div>
+
+            {% if mayoral_staff.updated_date %}
+            Last updated: {{ mayoral_staff.updated_date }}
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
One option is to have this in the model as done here. I don't think this justifies a cube. On the other hand this is a (cheap) query per cube.

The idea with last_updated is to be a partial ISO8061 time where the rest can be parsed as zeros - perhaps it's worth just having the full timestamp but that's kinda saying more than we can?

This is the precursor to being able to indicate somewhere "The contact details are correct as at xxxx and is updated quarterly"

The update_cycle values can match values in "period_length" which are currently year and month although "quarterly" and "annual" are really the terms used for this kind of thing 