### PR TITLE
Control where calculation items wrap

### DIFF
--- a/scorecard/templates/profile/profile_detail.html
+++ b/scorecard/templates/profile/profile_detail.html
@@ -364,7 +364,7 @@
       <h5>Formula:</h5>
 
       <ul class="formula">
-        <li>= (Budgeted Operating Expenditure - Actual Operating Expenditure) / Budgeted Operating Expenditure</li>
+        <li>= <span style="display: inline-block">(<span style="display: inline-block">Budgeted Operating Expenditure</span> <span style="display: inline-block">- Actual Operating Expenditure</span>)</span> <span style="display: inline-block">/ Budgeted Operating Expenditure</span></li>
         <li>=
           (<a href="{% table_url "incexp" year=latest.year items=4600 amountType="ADJB" %}" target="_blank">Income & Expenditure item code 4600, Adjusted Budget</a>
           -


### PR DESCRIPTION
What do you think of this POC of controlling how the calculation items wrap? The natural wrapping is confusing. This helps a lot, I think.

Another issue visible below is that at this size the Show Calculation link is in a weird place compared to the calculations
![wrap-control-and-calc-link](https://cloud.githubusercontent.com/assets/235801/15874512/bea4b10a-2d03-11e6-915b-d1e039b47e75.png)
