### PR TITLE
Make the focus of API websites the data, not the docs

### DIFF
--- a/models/badexp.json
+++ b/models/badexp.json
@@ -1,6 +1,6 @@
 {
     "fact_table": "badexp_facts",
-    "label": " Unauthorised, Irregular, Fruitless and Wasteful Expenditure",
+    "label": "Unauthorised, Irregular, Fruitless and Wasteful Expenditure",
     "description": "An audit outcome. Must be recorded in the notes to the annual financial statements",
     "update_cycle": "year",
     "last_updated": "2015",

--- a/municipal_finance/settings.py
+++ b/municipal_finance/settings.py
@@ -296,6 +296,7 @@ PIPELINE = {
                 'bower_components/backbone/backbone-min.js',
                 'javascript/vendor/d3-format.min.js',
                 'javascript/vendor/select2.min.js',
+                'javascript/vendor/js.cookie.js',
                 'bower_components/bootstrap-sass/assets/javascripts/bootstrap.min.js',
                 'javascript/table.js',
             ),

--- a/municipal_finance/static/javascript/table.js
+++ b/municipal_finance/static/javascript/table.js
@@ -167,7 +167,7 @@
 
       // show chosen munis
       if (munis.length === 0) {
-        $list.append('<li>').html('<i>Choose a municipality below.</i>');
+        $list.append('<li>').html('<i>Choose a municipality above.</i>');
       } else if (municipalities) {
         _.each(munis, function(muni) {
           muni = municipalities[muni];

--- a/municipal_finance/static/javascript/table.js
+++ b/municipal_finance/static/javascript/table.js
@@ -521,6 +521,12 @@
   /** Overall table view on this page
    */
   var MainView = Backbone.View.extend({
+    el: document,
+    events: {
+      'click button.accept': 'acceptTOU',
+      'click button.decline': 'declineTOU',
+    },
+
     initialize: function() {
       this.filters = new Filters();
       this.cells = new Cells();
@@ -531,6 +537,13 @@
 
       this.filterView = new FilterView({filters: this.filters, state: this.state});
       this.tableView = new TableView({filters: this.filters, cells: this.cells, state: this.state});
+
+      // show terms of use dialog?
+      if (!Cookies.get('tou-ok')) {
+        $('#terms-modal').modal();
+      } else {
+        this.acceptTOU();
+      }
     },
 
     saveState: function() {
@@ -567,6 +580,21 @@
         items: (params.items || "").split(","),
         amountType: (params.amountType),
       });
+    },
+
+    showTOU: function() {
+      $('#terms-modal').modal();
+    },
+
+    acceptTOU: function() {
+      Cookies.set('tou-ok', true);
+      $('#terms-modal').modal('hide');
+      $('#terms-ok').removeClass('hidden');
+    },
+
+    declineTOU: function() {
+      Cookies.remove('tou-ok');
+      window.location = "/";
     },
   });
 

--- a/municipal_finance/static/javascript/vendor/js.cookie.js
+++ b/municipal_finance/static/javascript/vendor/js.cookie.js
@@ -1,0 +1,151 @@
+/*!
+ * JavaScript Cookie v2.1.1
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+;(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+	} else if (typeof exports === 'object') {
+		module.exports = factory();
+	} else {
+		var OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				if (!converter.write) {
+					value = encodeURIComponent(String(value))
+						.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				} else {
+					value = converter.write(value, key);
+				}
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				return (document.cookie = [
+					key, '=', value,
+					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+					attributes.path    && '; path=' + attributes.path,
+					attributes.domain  && '; domain=' + attributes.domain,
+					attributes.secure ? '; secure' : ''
+				].join(''));
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var name = parts[0].replace(rdecode, decodeURIComponent);
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					cookie = converter.read ?
+						converter.read(cookie, name) : converter(cookie, name) ||
+						cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.set = api;
+		api.get = function (key) {
+			return api(key);
+		};
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init(function () {});
+}));

--- a/municipal_finance/static/stylesheets/site.scss
+++ b/municipal_finance/static/stylesheets/site.scss
@@ -34,7 +34,7 @@ $black: #333;
   .dataset {
     display: inline-block;
     float: left;
-    width: 24%;
+    width: 23%;
 
     border: 1px solid #ddd;
     border-radius: 5px;

--- a/municipal_finance/static/stylesheets/site.scss
+++ b/municipal_finance/static/stylesheets/site.scss
@@ -1,6 +1,7 @@
 /* national treasury colours */
 $nt-red: #AB2328;
 $nt-gold: #E6A65D;
+$black: #333;
 
 #header {
   height: 40px;
@@ -26,5 +27,46 @@ $nt-gold: #E6A65D;
     width: auto;
     height: 75px;
     margin-bottom: 20px;
+  }
+}
+
+.dataset-buttons {
+  .dataset {
+    display: inline-block;
+    float: left;
+    width: 24%;
+
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    margin: 0px 10px 10px 0px;
+    padding: 10px 10px;
+
+    color: $black;
+    background-color: #eee;
+
+    &:active,
+    &:focus,
+    &:hover {
+      text-decoration: none;
+    }
+
+    h4 {
+      margin: -10px -10px 10px;
+      padding: 10px 10px 10px;
+      border-bottom: 1px solid #ddd;
+    }
+
+    &:hover h4 {
+      background-color: $nt-red;
+      color: white;
+    }
+
+    &:hover {
+      border-color: $nt-red;
+    }
+
+    p:last-child {
+      margin-bottom: 0px;
+    }
   }
 }

--- a/municipal_finance/static/stylesheets/table.scss
+++ b/municipal_finance/static/stylesheets/table.scss
@@ -41,11 +41,16 @@ label {
 #header {
   padding: 5px 0px;
   background-color: $nt-red;
+  color: white;
 
   h1 {
     margin: 5px 0px 0px 140px;
-    color: white;
     font-size: 20px;
+    color: white;
+
+    a {
+      color: white;
+    }
   }
 
   .logo {
@@ -56,6 +61,21 @@ label {
     margin-right: 10px;
     background: white;
     top: 0px;
+  }
+
+  ul {
+    li {
+      float: left;
+      margin-left: 10px;
+    }
+
+    li.text {
+      padding: 7px 0px 0px 0px;
+      a {
+        color: white;
+        text-decoration: underline;
+      }
+    }
   }
 }
 

--- a/municipal_finance/templates/index.html
+++ b/municipal_finance/templates/index.html
@@ -36,27 +36,35 @@
 
   <div class="container">
     <div class="row">
-      <div class="col-sm-6 col-md-4 col-md-offset-2">
+      <div class="col-sm-4">
         <h2>4 years of data</h2>
         <p class="lead">Financial years 2012-2013 to 2015-2016.</p>
       </div>
 
-      <div class="col-sm-6 col-md-4">
+      <div class="col-sm-4">
         <h2>278 Municipalities</h2>
         <p class="lead">8 metros, 44 district and 226 local municipalities.</p>
       </div>
-    </div>
 
-    <div class="row">
-      <div class="col-sm-6 col-md-offset-2">
-        <h2>12 Datasets</h2>
-        <ul>
-          {% for cube in cubes|dictsort:"label" %}
-          <li>{{ cube.label }}</li>
-          {% endfor %}
-        </ul>
+      <div class="col-sm-4">
+        <h2>{{ cube_count }} Datasets</h2>
+        <p class="lead">Budgeted and actual figures for income and expenditure, cash flow and lots more.</p>
       </div>
     </div>
+
+    <h2>Explore a dateset</h2>
+
+    {% for group in cubes %}
+      <div class="dataset-buttons clearfix">
+      {% for cube_name, cube in group %}
+        <a href="/table/{{ cube_name }}/" class="dataset">
+          <h4>{{ cube.label}}</h4>
+          <p>{{ cube.description }}</p>
+          <p class="small">Updated: {{ cube.last_updated }}</p>
+        </a>
+      {% endfor %}
+      </div>
+    {% endfor %}
 
   </div>
 </article>

--- a/municipal_finance/templates/index.html
+++ b/municipal_finance/templates/index.html
@@ -27,10 +27,6 @@
       <p class="lead">
       Current and historical Municipal budget and financial performance data from the National Treasury.
       </p>
-
-      <p>
-      <a href="#" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#terms-modal">Get started</a>
-      </p>
     </div>
   </div>
 
@@ -65,6 +61,14 @@
       {% endfor %}
       </div>
     {% endfor %}
+
+    <h2>Build on the API</h2>
+
+    <p class="lead">All this data is available through a powerful but simple JSON API.</p>
+
+    <p>
+      <a href="/docs" class="btn btn-primary btn-lg">Read the API Docs</a>
+    </p>
 
   </div>
 </article>

--- a/municipal_finance/templates/index.html
+++ b/municipal_finance/templates/index.html
@@ -100,22 +100,4 @@
     </div>
   </section>
 </footer>
-
-<div class="modal fade" tabindex="-1" role="dialog" id="terms-modal">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-        <h4 class="modal-title">Please accept the Terms of Use</h4>
-      </div>
-      <div class="modal-body">
-        <p>[terms of use]</p>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <a href="/docs" class="btn btn-primary">Accept Terms of Use</a>
-      </div>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
 {% endblock %}

--- a/municipal_finance/templates/table.html
+++ b/municipal_finance/templates/table.html
@@ -14,10 +14,16 @@
 <header id="header">
   <div class="container-fluid">
     <div class="pull-right">
-      <a class="btn btn-default" href="/" target="_blank"><i class="fa fa-question-circle"></i> Help</a>
+      <ul class="list-unstyled">
+        <li id="terms-ok" class="text hidden">You've accepted the <a data-toggle="modal" href="#terms-modal">Terms of Use</a></li>
+        <li>
+          <a class="btn btn-default" href="/" target="_blank"><i class="fa fa-question-circle"></i> Help</a>
+        </li>
+      </ul>
     </div>
+
     <img src="{% static 'images/treasury-logo.jpg' %}" class="logo">
-    <h1>Municipal Money Data Tables</h1>
+    <h1><a href="/">Municipal Money Data Tables</a></h1>
   </div>
   <div id="spinner" class="progress-bar progress-bar-striped active"></div>
 </header>
@@ -78,6 +84,23 @@
     </section>
   </div>
 </article>
+
+<div class="modal fade" tabindex="-1" role="dialog" id="terms-modal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Please accept the Terms of Use</h4>
+      </div>
+      <div class="modal-body">
+        <p>[terms of use]</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default decline">Decline</button>
+        <button type="button" class="btn btn-primary accept">Accept Terms of Use</button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
 
 <script>
 

--- a/municipal_finance/views.py
+++ b/municipal_finance/views.py
@@ -16,9 +16,16 @@ def get_cube(name):
 
 @xframe_options_exempt
 def index(request):
-    cubes = [get_manager().get_cube(c).model.to_dict() for c in get_manager().list_cubes()]
+    mgr = get_manager()
+    cube_names = mgr.list_cubes()
+    cubes = [(c, mgr.get_cube(c).model.to_dict()) for c in cube_names]
+    cubes = sorted(cubes, key=lambda p: p[1]['label'])
+
+    # group into rows of four
+    cubes = [cubes[i:i + 4] for i in xrange(0, len(cubes), 4)]
     return render(request, 'index.html', {
         'cubes': cubes,
+        'cube_count': len(cube_names),
     })
 
 


### PR DESCRIPTION
* add direct links to the dataset table view from the landing page
* the table view saves a cookie for the Terms of Use and prompts the user to accept