### PR TITLE
Up gunicorn request limit to 7k

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: newrelic-admin run-program gunicorn --worker-class gevent municipal_finance.wsgi:application -t 600 --log-file -
+web: newrelic-admin run-program gunicorn --limit-request-line 7168 --worker-class gevent municipal_finance.wsgi:application -t 600 --log-file -


### PR DESCRIPTION
See
http://docs.gunicorn.org/en/latest/settings.html?highlight=limit_request_line

This prevents errors when specifying all municipalities by code