### PR TITLE
Final tweaks

### DIFF
--- a/scorecard/templates/profile/_about.html
+++ b/scorecard/templates/profile/_about.html
@@ -85,7 +85,7 @@
               <p>Last updated: {{ mayoral_staff.updated_date }}</p>
               {% endif %}
 
-              <p><strong>Note:</strong> Mayoral staff may have changed due to the 2016 Municipal Elections. We will provide updated information when we have it.</p>
+              <p><strong>Note:</strong> Mayoral positions may have changed due to the 2016 Municipal Elections. We will provide updated information when we have it.</p>
             </div>
           </div>
 

--- a/scorecard/templates/profile/_income.html
+++ b/scorecard/templates/profile/_income.html
@@ -6,7 +6,7 @@
   <div class="income-split indicator">
     <div class="row">
       <div class="col-md-8">
-        <h2 class="text-center">{{ geography.name }} gets money from two sources</h2>
+        <h2 class="text-center">Where does {{ geography.name }} get its money from?</h2>
       </div>
     </div>
 

--- a/scorecard/templates/profile/_performance.html
+++ b/scorecard/templates/profile/_performance.html
@@ -514,7 +514,7 @@
 
   <div class="indicator">
     {% with indicators.current_debtors_collection_rate.values|first as latest %}
-    <h2>Current Debtors Collection Rate <span class="indicator-date">{{ latest.year|finyear }} Quarter {{ latest.quarter }}</span></h2>
+    <h2>Current Debtors Collection Ratio <span class="indicator-date">{{ latest.year|finyear }} Quarter {{ latest.quarter }}</span></h2>
 
     <div class="row">
       <div class="col-sm-4">

--- a/scorecard/templates/profile/_performance.html
+++ b/scorecard/templates/profile/_performance.html
@@ -443,6 +443,7 @@
           <div class="panel-heading"><i class="fa fa-info-circle" aria-hidden="true"></i> Did you know?</div>
           <div class="panel-body">
             <p>The current ratio compares the value of a municipality's short-term assets (cash, bank deposits, etc) compared with its short-term liabilities (creditors, loans due and so on). The higher the ratio, the better. The normal range of the current ratio is 1.5 to 2 (the municipality has assets more than 1.5 to 2 times its current debts). Anything less than that and the municipality may struggle to keep up with its payments.</p>
+            <a href="https://www.youtube.com/embed/tLFJvfARUic" class="video-link"><i class="fa fa-play fa-fw" aria-hidden="true"></i>Play video</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
* Under the contact details banner, change “Mayoral staff” to “Mayoral positions"
* Change 'Current Debtors’ Collection Rate' heading to read  ‘Current Debtors’ Collection Ratio’ so that it aligns with the headings we are using on the video clips. 
* “Income” we recently asked you to add the name of the municipality in the heading “ x municipality gets money from two sources”.  Please can we change that to “Where does x municipality get its money from?”  
* The link to the Liquidity video clip is also to be added to the Current Ratio indicator.  We covered both indicators in one clip.