### PR TITLE
Link from "Not available" in scorecard to FAQ entry

### DIFF
--- a/scorecard/static/stylesheets/scorecard.scss
+++ b/scorecard/static/stylesheets/scorecard.scss
@@ -207,7 +207,7 @@ blockquote {
       margin-left: 30px;
     }
   }
-  
+
   .search {
     float: right;
     margin-top: 4px;
@@ -684,7 +684,7 @@ blockquote {
     transform-style: preserve-3d;
     height: 150px;
   }
-  .video-image:after { 
+  .video-image:after {
     background: rgba(0,0,0,0.7);
     content: "";
     position: absolute;
@@ -783,7 +783,7 @@ blockquote {
   }
 }
 
-// audit-opinions 
+// audit-opinions
 #more-audit-opinions {
   h3,h4 {
     text-align: center;
@@ -955,6 +955,11 @@ blockquote {
     color: $gray-light;
     font-weight: normal;
     white-space: nowrap;
+  }
+  .faq-link {
+    margin-bottom: 8px;
+    font-size: 13px;
+    line-height: 1;
   }
   .indicator-description {
     margin-bottom: 5px;
@@ -1404,7 +1409,7 @@ blockquote {
 
     overflow-y: hidden;
   }
-  
+
   .frame-right {
     left: 50%;
     border-left: 5px solid $gray-lighter;

--- a/scorecard/templates/profile/_performance.html
+++ b/scorecard/templates/profile/_performance.html
@@ -96,7 +96,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}R {{ latest.result|floatformat:"0" }}{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          R {{ latest.result|floatformat:"0" }}
+          {% endif %}
+        </div>
         <div class="indicator-description">Cash balance at the end of the financial year.</div>
         <table class="indicator-key">
           <tr>
@@ -143,7 +150,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result|month_days }}{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result|month_days }}
+          {% endif %}
+        </div>
         <div class="indicator-description">Months of operating expenses can be paid for with the cash available.</div>
         <table class="indicator-key">
           <tr>
@@ -198,7 +212,8 @@
       <div class="col-sm-4">
         <div class="indicator-value rating rating-{{ latest.rating }}">
           {% if latest.result == None %}
-            Not available
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
           {% else %}
             {{ latest.result|absolute }}%
             {% if latest.result != 0 %}{{ latest.overunder }}spent{% endif %}
@@ -261,6 +276,7 @@
         <div class="indicator-value rating rating-{{ latest.rating }}">
           {% if latest.result == None %}
             Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
           {% else %}
             {{ latest.result|absolute }}%
             {% if latest.result != 0 %}{{ latest.overunder }}spent{% endif %}
@@ -320,7 +336,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result }}%{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}%
+          {% endif %}
+        </div>
 
         <div class="indicator-description">Spending on Repairs and Maintenance as a percentage of Property, Plant and Equipment.</div>
         <table class="indicator-key">
@@ -372,7 +395,13 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result }}%{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}{{ latest.result }}%
+          {% endif %}
+        </div>
         <div class="indicator-description">Unauthorised, Irregular, Fruitless and Wasteful Expenditure as a percentage of operating expenditure.</div>
         <table class="indicator-key">
           <tr>
@@ -421,7 +450,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result }}{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}
+          {% endif %}
+        </div>
         <div class="indicator-description">The value of a municipality's short-term assets as a multiple of its short-term liabilities.</div>
         <table class="indicator-key">
           <tr>
@@ -474,7 +510,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result }}{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}
+          {% endif %}
+        </div>
         <div class="indicator-description">The municipality's immediate ability to pay its current liabilities</div>
         <table class="indicator-key">
           <tr>
@@ -522,7 +565,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value rating rating-{{ latest.rating }}">{% if latest.result == None %}Not available{% else %}{{ latest.result }}%{% endif %}</div>
+        <div class="indicator-value rating rating-{{ latest.rating }}">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}%
+          {% endif %}
+        </div>
         <div class="indicator-description">The percentage of new revenue (generated within the financial year) that a municipality actually collects</div>
         <table class="indicator-key">
           <tr>

--- a/scorecard/templates/profile/_spending.html
+++ b/scorecard/templates/profile/_spending.html
@@ -9,7 +9,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value">{% if latest.result == None %}Not available{% else %}{{ latest.result }}%{% endif %}</div>
+        <div class="indicator-value">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}%
+          {% endif %}
+        </div>
         <div class="indicator-description">Staff salaries and wages as a percentage of operating expenditure.</div>
         <table class="indicator-key">
           <tr>
@@ -56,7 +63,14 @@
 
     <div class="row">
       <div class="col-sm-4">
-        <div class="indicator-value">{% if latest.result == None %}Not available{% else %}{{ latest.result }}%{% endif %}</div>
+        <div class="indicator-value">
+          {% if latest.result == None %}
+          Not available
+          <div class="faq-link"><a href="/faq#info-not-available" target="blank">What does this mean?</a></div>
+          {% else %}
+          {{ latest.result }}%
+          {% endif %}
+        </div>
         <div class="indicator-description">Costs of contractor services as a percentage of operating expenditure.</div>
         <table class="indicator-key">
           <tr>


### PR DESCRIPTION
I don't think it's clear where to find the explanation of the asterisk - especially since it's not clear it's hyperlinked.

![not-avail-astrerisk](https://cloud.githubusercontent.com/assets/235801/18469571/fa252f60-79a8-11e6-8613-a868fbe4d1d5.png)

But the underline on the subscript doesn't look good

![not-avail-asterisk-hover](https://cloud.githubusercontent.com/assets/235801/18469570/f9e4051c-79a8-11e6-8d68-ac265c2640be.png)

The text looks kinda useful, but without underline it looks more like a heading for the description below

![not-avail-text](https://cloud.githubusercontent.com/assets/235801/18469613/2290f95c-79a9-11e6-962d-1979cb801b12.png)

I think with underline (always, not just on hover) it works - even though it makes the indicator busier.

![not-avail-text-hover](https://cloud.githubusercontent.com/assets/235801/18469611/228c981c-79a9-11e6-80b2-352ff646bcaf.png)


