### PR TITLE
Hide out of date political appointments and explain

### DIFF
--- a/scorecard/templates/profile/_about.html
+++ b/scorecard/templates/profile/_about.html
@@ -26,7 +26,56 @@
         <div class="col-md-8">
           <div class="row">
             {% for official in mayoral_staff.officials %}
-              {% if forloop.counter < 5 %}
+              {% if forloop.counter == 1 or forloop.counter == 3 %}
+              <div class="col-sm-3">
+                <div class="person-info">
+                  <div class="person-role">{{ official.role }}</div>
+                  <ul class="fa-ul person-name">
+                    {% if official and official.name %}
+                    <li><i class="fa fa-li fa-user" aria-hidden="true"></i> - </li>
+                    {% endif %}
+                  </ul>
+                  <div class="person-contact-details">
+                    <a href="#contact-details-{{ forloop.counter }}" data-toggle="collapse" class="show-contact-details show-more"><span class="icon"><i class="fa fa-plus" aria-hidden="true"></i></span> Contact Details</a>
+
+                    <div class="contact-details collapse" id="contact-details-{{ forloop.counter }}">
+                      <ul class="fa-ul">
+                        {% if official.office_phone %}
+                        <li>
+                          <i class="fa fa-li fa-phone" aria-hidden="true"></i> -
+                        </li>
+                        {% endif %}
+                        {% if official.email %}
+                        <li>
+                          <i class="fa fa-li fa-envelope" aria-hidden="true"></i> -
+                        </li>
+                        {% endif %}
+                      </ul>
+
+                      {% if official.secretary %}
+                        <div>
+                          <h4>Secretary</h4>
+                        </div>
+
+                        <ul class="fa-ul">
+                          {% if official.secretary.name %}
+                          <li><i class="fa fa-li fa-user" aria-hidden="true"></i> - </li>
+                          {% endif %}
+
+                          {% if official.secretary.office_phone %}
+                          <li><i class="fa fa-li fa-phone" aria-hidden="true"></i> - </li>
+                          {% endif %}
+
+                          {% if official.secretary.email %}
+                          <li><i class="fa fa-li fa-envelope" aria-hidden="true"></i> - </li>
+                          {% endif %}
+                        </ul>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              {% elif forloop.counter < 5 %}
               <div class="col-sm-3">
                 <div class="person-info">
                   <div class="person-role">{{ official.role }}</div>
@@ -85,7 +134,7 @@
               <p>Last updated: {{ mayoral_staff.updated_date }}</p>
               {% endif %}
 
-              <p><strong>Note:</strong> Mayoral positions may have changed due to the 2016 Municipal Elections. We will provide updated information when we have it.</p>
+              <p><strong>Note:</strong> Mayoral staff and contact details are updated quarterly. Due to the recent municipal elections, the political appointments are not yet available and will be updated in the next quarterly update in December 2016.</p>
             </div>
           </div>
 


### PR DESCRIPTION
Don't show mayor or deputy mayor since those positions are out of date since the local elections. Keep the places to indicate that this information exists and will come soon.

Explain a) that it's updated quarterly and b) that they're hidden because of the recent elections.

I think mentioning "political appointments" works a little toward educating that mayor and deputy are appointed differently from managers.

![muni-money-mayoral-contacts-2016](https://cloud.githubusercontent.com/assets/235801/19645252/277f2856-99f4-11e6-8878-863cc0e029ac.png)
