### PR TITLE
Set DB statement timeout to 10s to reduce impact of overload

### DIFF
--- a/municipal_finance/cubes.py
+++ b/municipal_finance/cubes.py
@@ -40,6 +40,10 @@ class PreloadingJSONCubeManager(JSONCubeManager):
     def get_cube_model(self, name):
         return self._models[name]
 
+
+class APIOverloadedException(BaseException):
+    pass
+
 _cube_manager = None
 
 

--- a/municipal_finance/middleware.py
+++ b/municipal_finance/middleware.py
@@ -1,5 +1,7 @@
 from django.contrib.sites.shortcuts import get_current_site
+from django.http import HttpResponse
 from django.http import HttpResponsePermanentRedirect
+from cubes import APIOverloadedException
 
 from utils import jsonify
 

--- a/municipal_finance/settings.py
+++ b/municipal_finance/settings.py
@@ -102,6 +102,8 @@ WSGI_APPLICATION = 'municipal_finance.wsgi.application'
 
 
 # Database
+os.environ['PGOPTIONS'] = '-c statement_timeout=10000'
+
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases
 import dj_database_url
 DATABASE_URL = os.environ.get('DATABASE_URL', 'postgres://municipal_finance:municipal_finance@localhost:5432/municipal_finance')


### PR DESCRIPTION
 This means long queries will fail instead of queuing and building up to
 hours of downtime.

 Also start handling the error nicely. Currently we just get internal feedback
 of "APIOverloadedException" but I'd like to turn that into a "We're oh so popular"
 message when I figure out how to use 'process_exception' correctly