### PR TITLE
Use generation 2 maps in general, 1 for old munis

### DIFF
--- a/scorecard/static/js/maps.js
+++ b/scorecard/static/js/maps.js
@@ -43,10 +43,10 @@ function MapItGeometryLoader() {
     });
   };
 
-  this.loadGeometryForGeo = function(geo_level, geo_code, success) {
+  this.loadGeometryForGeo = function(geo_level, geo_code, generation, success) {
     var mapit_type = MAPIT.level_codes[geo_level];
     var mapit_simplify = MAPIT.level_simplify[mapit_type];
-    var url = "/area/MDB:" + geo_code + "/feature.geojson?generation=1&simplify_tolerance=" + mapit_simplify +
+    var url = "/area/MDB:" + geo_code + "/feature.geojson?generation=" + generation + "&simplify_tolerance=" + mapit_simplify +
       "&type=" + mapit_type;
 
     d3.json(this.mapit_url + url, function(error, feature) {
@@ -86,13 +86,23 @@ var Maps = function() {
     "fillOpacity": 0.7,
   };
 
-  this.drawMapsForProfile = function(geo) {
+  this.drawMapsForProfile = function(geo, demarcation) {
     this.geo = geo;
     this.createMap();
     this.addImagery();
 
+    // for 2011 munis, we load generation 1 maps, otherwise we load 2016 (generation 2) maps
+    var generation = 2;
+    if (demarcation.disestablished) {
+      generation = 1;
+      this.featureGeoStyle.fillColor = "#fdcd58";
+      this.featureGeoStyle.fillOpacity = 0.7;
+      this.featureGeoStyle.color = "#fdcd58";
+      this.featureGeoStyle.opacity = 1.0;
+    }
+
     // draw this geometry
-    GeometryLoader.loadGeometryForGeo(this.geo.geo_level, this.geo.geo_code, function(feature) {
+    GeometryLoader.loadGeometryForGeo(this.geo.geo_level, this.geo.geo_code, generation, function(feature) {
       self.drawFocusFeature(feature);
     });
 

--- a/scorecard/templates/profile/profile_detail.html
+++ b/scorecard/templates/profile/profile_detail.html
@@ -139,7 +139,7 @@
 
   var profileData = {{ profile_data|jsonify|safe }}
   var maps = new Maps();
-  maps.drawMapsForProfile(profileData.geography);
+  maps.drawMapsForProfile(profileData.geography, profileData.demarcation);
 
 </script>
 


### PR DESCRIPTION
For disestablished munis, we show the old boundary in yellow (to match the colour of the warning banner), and then load the 2016 boundaries on top of that.

<img alt="mbombela - municipal money 2016-12-08 15-45-55" src="https://cloud.githubusercontent.com/assets/4178542/21012289/f7a57eea-bd5d-11e6-9ff9-9eb5ce069fbf.png">

when hovering:
<img width="1099" alt="screen shot 2016-12-08 at 3 46 16 pm" src="https://cloud.githubusercontent.com/assets/4178542/21012288/f778b950-bd5d-11e6-834c-31e674284058.png">

